### PR TITLE
Warnings and flexibility re: upper and lower bounds on model parameters

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -83,13 +83,19 @@ calculateBIC <- function(LL, nparams, samplesize) {
     return(-2 * LL + nparams * log(samplesize))
 }
 
-multioptimFit <- function(time_data, mass_data, model, iters = 200, ...) {
+multioptimFit <- function(time_data, mass_data, model, iters = 200,upper=NULL,lower=NULL, ...) {
     nArgs <- length(formals(model)) - 3
     # need this to allow variation in number of parameters (changed to 3 because 'upper' and 'lower' are
     # now formal arguments)
     fit <- list()
-    upper_bounds <- eval(as.list(formals(model))$upper)
-    lower_bounds <- eval(as.list(formals(model))$lower)
+    ifelse(!is.null(upper),
+           upper_bounds <- upper,
+           upper_bounds <- eval(as.list(formals(model))$upper))
+           
+    ifelse(!is.null(lower),
+           lower_bounds <- lower,
+           lower_bounds <- eval(as.list(formals(model))$lower))
+
     for (i in 1:iters) {
         starter <- runif(nArgs, min = lower_bounds, max = lower_bounds + 0.9998)
         # always start near lower bound--empirically works better

--- a/R/optim-fxns.R
+++ b/R/optim-fxns.R
@@ -86,5 +86,9 @@ fit_litter <- function(time, mass.remaining, model = c("neg.exp", "weibull", "di
     fit.out <- list(optimFit = fit, logLik = LL, fitAIC = model.AIC, fitAICc = model.AICc, fitBIC = model.BIC, 
         time = time, mass = mass.remaining, predicted = predicted_vals, model = model, nparams = nps)
     class(fit.out) <- "litfit"
+    if(any(fit.out$optimFit$par == eval(formals(get(model))$lower) |
+       fit.out$optimFit$par == eval(formals(get(model))$upper))) {
+      warning("one or more parameters fit on the boundary, check fit closely")
+    }
     return(fit.out)
 } 

--- a/R/pineneedles-data.R
+++ b/R/pineneedles-data.R
@@ -6,4 +6,4 @@
 ##' @format a data.frame with two columns
 ##' @source Hobbie et al.
 ##' @author Will Cornwell 
-"pineneedles" 
+NULL 

--- a/man/fit_litter.Rd
+++ b/man/fit_litter.Rd
@@ -7,7 +7,7 @@
 \usage{
 fit_litter(time, mass.remaining, model = c("neg.exp", "weibull",
   "discrete.parallel", "discrete.series", "cont.quality.1", "cont.quality.2",
-  "neg.exp.limit"), iters = 500, ...)
+  "neg.exp.limit"), iters = 500, upper = NULL, lower = NULL, ...)
 }
 \arguments{
 \item{time}{time since decomposition began, that is, ti-t0}
@@ -17,6 +17,10 @@ fit_litter(time, mass.remaining, model = c("neg.exp", "weibull",
 \item{model}{there are five models currently implemented (see below)}
 
 \item{iters}{Number of random starts for the fitting.  Use higher numbers for models with larger numbers of parameters and for models that inherently tend to be less identifiable.}
+
+\item{upper,lower}{\bold{Optional} user specified values for the upper and lower bounds used by
+\code{optim} in the fitting procedure. Use with care, only minimal sanity checking is currently
+ implemented.}
 
 \item{...}{Additional arguments passed to \code{\link{optim}}}
 }

--- a/man/pineneedles.Rd
+++ b/man/pineneedles.Rd
@@ -17,5 +17,4 @@ data from Hobbie et al means of pine needle decomposition
 \author{
 Will Cornwell
 }
-\keyword{datasets}
 


### PR DESCRIPTION
`fit_litter` now throws a warning if one or more parameter is equal to its respective upper or lower bound. E.g. try

```r
fit<-fit_litter(time=pineneedles$Year,mass.remaining=pineneedles$Mass.remaining,
                model='discrete.series',iters=100)
```

Users can now specify the upper or lower bounds in the original `fit_litter` call. At present the only checking is that the correct number of parameters for the chosen model are supplied. There is a warning in the documentation to use this carefully - in the future we could add other sanity checks (e.g. `upper > lower`). Much harder would be to enforce bounds implicit in the model (i.e. that partitioning parameters are [0,1] that decay constants > 0 etc.

On second thoughts, maybe the warning in the documentation should mention these issues.